### PR TITLE
Fix RuboCop plugin loading inconsistency between direct and rake execution

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,21 +15,21 @@ inherit_mode:
     - Exclude
 
 plugins:
-  # - rubocop-capybara
-  # - rubocop-i18n
+  - rubocop-capybara
+  - rubocop-i18n
   - rubocop-performance
   - rubocop-rake
   - rubocop-rspec
-  # - rubocop-sequel
-  # - rubocop-thread_safety
+  - rubocop-sequel
+  - rubocop-thread_safety
 
 inherit_from:
   - config/cops/bundler.yml
-  # - config/cops/capybara.yml
-  # - config/cops/capybara_rspec.yml
+  - config/cops/capybara.yml
+  - config/cops/capybara_rspec.yml
   - config/cops/gemspec.yml
-  # - config/cops/i18n_gettext.yml
-  # - config/cops/i18n_railsi18n.yml
+  - config/cops/i18n_gettext.yml
+  - config/cops/i18n_railsi18n.yml
   - config/cops/layout.yml
   - config/cops/lint.yml
   - config/cops/metrics.yml
@@ -39,9 +39,9 @@ inherit_from:
   - config/cops/rake.yml
   - config/cops/rspec.yml
   - config/cops/security.yml
-  # - config/cops/sequel.yml
+  - config/cops/sequel.yml
   - config/cops/style.yml
-  # - config/cops/thread_safety.yml
+  - config/cops/thread_safety.yml
   - .rubocop_todo.yml
 
 # Project-specific settings can be added here

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,4 +44,14 @@ inherit_from:
   - config/cops/thread_safety.yml
   - .rubocop_todo.yml
 
-# Project-specific settings can be added here
+# Project-specific settings
+# Disable I18n cops as this project is not intended for internationalization
+I18n/GetText/DecorateString:
+  Enabled: false
+
+I18n/RailsI18n/DecorateString:
+  Enabled: false
+
+# Disable ThreadSafety cops as this is a CLI tool where thread safety is not a primary concern
+ThreadSafety:
+  Enabled: false

--- a/config/defaults/thread_safety.yml
+++ b/config/defaults/thread_safety.yml
@@ -1,23 +1,23 @@
 # Department 'ThreadSafety' (6):
-# https://docs.rubocop.org/rubocop/cops_threadsafety.html#threadsafetyclassandmoduleattributes
+# https://docs.rubocop.org/rubocop-thread_safety/cops_thread_safety.html#threadsafetyclassandmoduleattributes
 ThreadSafety/ClassAndModuleAttributes:
   Description: Avoid mutating class and module attributes.
   Enabled: true
   ActiveSupportClassAttributeAllowed: false
 
-# https://docs.rubocop.org/rubocop/cops_threadsafety.html#threadsafetyclassinstancevariable
+# https://docs.rubocop.org/rubocop-thread_safety/cops_thread_safety.html#threadsafetyclassinstancevariable
 ThreadSafety/ClassInstanceVariable:
   Description: Avoid class instance variables.
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_threadsafety.html#threadsafetydirchdir
+# https://docs.rubocop.org/rubocop-thread_safety/cops_thread_safety.html#threadsafetydirchdir
 ThreadSafety/DirChdir:
   Description: Avoid using `Dir.chdir` due to its process-wide effect.
   Enabled: true
   AllowCallWithBlock: false
 
 # Supports --autocorrect
-# https://docs.rubocop.org/rubocop/cops_threadsafety.html#threadsafetymutableclassinstancevariable
+# https://docs.rubocop.org/rubocop-thread_safety/cops_thread_safety.html#threadsafetymutableclassinstancevariable
 ThreadSafety/MutableClassInstanceVariable:
   Description: Do not assign mutable objects to class instance variables.
   Enabled: true
@@ -27,12 +27,12 @@ ThreadSafety/MutableClassInstanceVariable:
   - literals
   - strict
 
-# https://docs.rubocop.org/rubocop/cops_threadsafety.html#threadsafetynewthread
+# https://docs.rubocop.org/rubocop-thread_safety/cops_thread_safety.html#threadsafetynewthread
 ThreadSafety/NewThread:
   Description: Avoid starting new threads. Let a framework like Sidekiq handle the threads.
   Enabled: true
 
-# https://docs.rubocop.org/rubocop/cops_threadsafety.html#threadsafetyrackmiddlewareinstancevariable
+# https://docs.rubocop.org/rubocop-thread_safety/cops_thread_safety.html#threadsafetyrackmiddlewareinstancevariable
 ThreadSafety/RackMiddlewareInstanceVariable:
   Description: Avoid instance variables in Rack middleware.
   Enabled: true

--- a/lib/docquet.rb
+++ b/lib/docquet.rb
@@ -7,7 +7,7 @@ require_relative "docquet/cli/regenerate_todo"
 require_relative "docquet/config_processor"
 require_relative "docquet/generators/rubocop_yml_generator"
 require_relative "docquet/inflector"
-require_relative "docquet/rake_task"
+# require_relative "docquet/rake_task" # Disabled to avoid loading all RuboCop plugins when using docquet command in other projects
 require_relative "docquet/version"
 
 module Docquet

--- a/lib/docquet.rb
+++ b/lib/docquet.rb
@@ -7,7 +7,8 @@ require_relative "docquet/cli/regenerate_todo"
 require_relative "docquet/config_processor"
 require_relative "docquet/generators/rubocop_yml_generator"
 require_relative "docquet/inflector"
-# require_relative "docquet/rake_task" # Disabled to avoid loading all RuboCop plugins when using docquet command in other projects
+# Disabled to avoid loading all RuboCop plugins when using docquet command in other projects
+# require_relative "docquet/rake_task"
 require_relative "docquet/version"
 
 module Docquet

--- a/lib/docquet/rake_task.rb
+++ b/lib/docquet/rake_task.rb
@@ -1,25 +1,30 @@
 # frozen_string_literal: true
 
+# Only load in docquet gem development environment
+unless File.exist?("docquet.gemspec")
+  warn "Warning: docquet/rake_task loaded outside of docquet project - skipping loading"
+  return
+end
+
+# Standard library and framework requires
 require "fileutils"
 require "rake/tasklib"
-require "rubocop"
-
-# プラグインの条件付き読み込み
-%w[
-  rubocop-capybara
-  rubocop-i18n
-  rubocop-performance
-  rubocop-rake
-  rubocop-rspec
-  rubocop-sequel
-  rubocop-thread_safety
-].each do |plugin|
-  require plugin
-rescue LoadError
-  # Skip silently if the plugin is not available
-end
 require "uri"
 require "yaml"
+
+# RuboCop core
+require "rubocop"
+
+# RuboCop plugins
+require "rubocop-capybara"
+require "rubocop-i18n"
+require "rubocop-performance"
+require "rubocop-rake"
+require "rubocop-rspec"
+require "rubocop-sequel"
+require "rubocop-thread_safety"
+
+# Local requires
 require_relative "config_processor"
 require_relative "inflector"
 require_relative "plugin_detector"


### PR DESCRIPTION
## Summary
- Fixed inconsistency where `bundle exec rubocop` succeeded but `bundle exec rake rubocop` failed with Capybara cop errors
- Enabled all RuboCop plugins in `.rubocop.yml` for consistent behavior across execution methods
- Added project scope protection to `rake_task.rb` to prevent plugin loading issues in other projects
- Disabled I18n and ThreadSafety cops as they are not relevant for this CLI tool

## Changes
- **`.rubocop.yml`**: Enabled all plugins and disabled I18n/ThreadSafety cops
- **`lib/docquet.rb`**: Commented out `rake_task` require to prevent plugin conflicts in other projects
- **`lib/docquet/rake_task.rb`**: Added gemspec check with warning for wrong project usage, reorganized requires

## Test plan
- [x] `bundle exec rubocop` passes
- [x] `bundle exec rake rubocop` passes  
- [x] `bundle exec rake docquet:regenerate` works correctly
- [x] All plugins load properly during rule generation

:robot: Generated with [Claude Code](https://claude.ai/code)
